### PR TITLE
Update msgbuf struct data types

### DIFF
--- a/manual_code/Context_Switching_IPROC/src/common.h
+++ b/manual_code/Context_Switching_IPROC/src/common.h
@@ -127,9 +127,9 @@ typedef struct proc_init
 typedef struct msgbuf
 {
 #ifdef K_MSG_ENV
-    void *mp_next;              /**> ptr to next message received*/
-    int m_send_pid;             /**> sender pid                  */
-    int m_recv_pid;             /**> receiver pid                */
+    struct msgbuf *mp_next;     /**> ptr to next message received*/
+    U32 m_send_pid;             /**> sender pid                  */
+    U32 m_recv_pid;             /**> receiver pid                */
     int m_kdata[5];             /**> extra 20B kernel data place holder */
 #endif
     int mtype;                  /**> user defined message type   */


### PR DESCRIPTION
Looking at the initial provided PCB (https://github.com/yqh/SE350/blob/master/manual_code/Context_Switching_IPROC/src/k_inc.h#L75), `mp_next` has type `struct pcb` and the `m_pid` has type U32. 

Can we keep the same for msgbuf? This way generic implementations of linked list are not impacted and cause compilation errors.